### PR TITLE
Use datetime_display property in api response to figure out time quiz was generated.

### DIFF
--- a/src/__tests__/to-timestamp.spec.ts
+++ b/src/__tests__/to-timestamp.spec.ts
@@ -4,6 +4,6 @@ describe('Import TimeStamp', () => {
   it('Should return same day', () => {
     const date = new Date('2021-07-28T00:00:00.000+12:00');
     const stamp = toTimestamp(date);
-    expect(stamp).toBe('July 28');
+    expect(stamp).toBe('28/07/2021');
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,10 +8,17 @@ async function* main(infra: Infra): AsyncGenerator<Link> {
     `https://i.stuff.co.nz/_json/national/quizzes`
   );
 
-  for (const { title, html_assets, datetime_display } of recentQuizzes.stories) {
+  for (const {
+    title,
+    html_assets,
+    datetime_display,
+  } of recentQuizzes.stories) {
     const timestamp = toTimestamp(infra.now());
 
-    if (title.indexOf('Sport') !== -1 || datetime_display.indexOf(timestamp) === -1) {
+    if (
+      title.indexOf('Sport') !== -1 ||
+      datetime_display.indexOf(timestamp) === -1
+    ) {
       continue;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,10 +8,10 @@ async function* main(infra: Infra): AsyncGenerator<Link> {
     `https://i.stuff.co.nz/_json/national/quizzes`
   );
 
-  for (const { title, html_assets } of recentQuizzes.stories) {
+  for (const { title, html_assets, datetime_display } of recentQuizzes.stories) {
     const timestamp = toTimestamp(infra.now());
 
-    if (title.indexOf('Sport') !== -1 || title.indexOf(timestamp) === -1) {
+    if (title.indexOf('Sport') !== -1 || datetime_display.indexOf(timestamp) === -1) {
       continue;
     }
 

--- a/src/quizzes.ts
+++ b/src/quizzes.ts
@@ -6,6 +6,7 @@ type Story = {
   path: string;
   title: string;
   html_assets: HtmlAsset[];
+  datetime_display: string;
 };
 
 type Quizzes = {

--- a/src/to-timestamp.ts
+++ b/src/to-timestamp.ts
@@ -1,13 +1,18 @@
 export default (date: Date): string => {
   const month = date.toLocaleString('en-NZ', {
     timeZone: 'Pacific/Auckland',
-    month: 'long',
+    month: '2-digit',
   });
 
   const day = date.toLocaleString('en-NZ', {
     timeZone: 'Pacific/Auckland',
-    day: 'numeric',
+    day: '2-digit',
   });
 
-  return `${month} ${day}`;
+  const year = date.toLocaleString('en-NZ', {
+    timeZone: 'Pacific/Auckland',
+    year: 'numeric',
+  });
+
+  return `${day}/${month}/${year}`;
 };


### PR DESCRIPTION
Why?
We were previously using the quiz title. For some reason the api is sometimes including a comma in the title such as "Quiz: Morning trivia challenge: April, 27, 2022". Because the comma between april and 27 isn't consistent our parsing method only works some times.
This change uses the datetime_display property instead which comes with a date formatted like so: "05:00 27/04/2022"

Steps to reproduce:
- Run `npx unstuffy` 
- The output won't include the morning trivia quiz for today 
You can check the api response for today [here](https://i.stuff.co.nz/_json/national/quizzes)